### PR TITLE
Fix aksepter dubletter ved sjekk av eksisterende inntektsmeldinger for referanseId

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/historikk/tjenester/inntektsmelding/Inntektsmelding.java
+++ b/src/main/java/no/nav/foreldrepenger/historikk/tjenester/inntektsmelding/Inntektsmelding.java
@@ -65,7 +65,7 @@ public class Inntektsmelding {
         if (INGEN_REFERANSE.equals(referanseId)) {
             return false;
         }
-        return referanseId != null && dao.findByReferanseId(referanseId) != null;
+        return referanseId != null && dao.existsJPAInntektsmeldingInnslagByReferanseId(referanseId);
     }
 
     @Override

--- a/src/main/java/no/nav/foreldrepenger/historikk/tjenester/inntektsmelding/JPAInntektsmeldingRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/historikk/tjenester/inntektsmelding/JPAInntektsmeldingRepository.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(JPA_TM)
 public interface JPAInntektsmeldingRepository
         extends JpaRepository<JPAInntektsmeldingInnslag, Long>, JpaSpecificationExecutor<JPAInntektsmeldingInnslag> {
-    JPAInntektsmeldingInnslag findByReferanseId(String referanseId);
+
+    boolean existsJPAInntektsmeldingInnslagByReferanseId(String referanseId);
 
 }


### PR DESCRIPTION
Bruker inferred query. Ser det er tynt med test av det. Det gjøres validering ved oppstart av boot, men slet med å få config inn for å dra opp application context.